### PR TITLE
if boolean facet has two or more items enable filter button

### DIFF
--- a/src/facets.coffee
+++ b/src/facets.coffee
@@ -1120,7 +1120,7 @@ do ->
 
     initialize: ->
       super(arguments...)
-      if @items.length is 2
+      if @items.length > 1 
         @items.on 'change:selected', (x, selected) =>
           @items.each (y) -> y.set(selected: false) if (selected and x isnt y)
           someAreSelected = @items.any((item) -> !! item.get "selected")


### PR DESCRIPTION
When there is a Boolean field with nulls the existing check for 'items is 2' means that column can not be filtered on.  Addresses issue https://github.com/intermine/intermine/issues/641
