### PR TITLE
Fixed Intermine #1659 and im-tables # 162

### DIFF
--- a/src/views/code-gen-dialogue.js
+++ b/src/views/code-gen-dialogue.js
@@ -25,7 +25,7 @@ const stripExtraneousWhiteSpace = require('../utils/strip-extra-whitespace');
 const withResource = require('../utils/with-cdn-resource');
 
 // Comment finding regexen
-const OCTOTHORPE_COMMENTS = /\s*#.*$/gm;
+const OCTOTHORPE_COMMENTS = /\s*#[^!].*$/gm;
 const C_STYLE_COMMENTS = /\/\*(\*(?!\/)|[^*])*\*\//gm; // just strip blocks.
 const XML_MIMETYPE = 'application/xml;charset=utf8';
 const JS_MIMETYPE = 'text/javascript;charset=utf8';


### PR DESCRIPTION
Hi,
This pull request fixes intermine bug 1659:
[https://github.com/intermine/intermine/issues/1659](url)
and im-tables bug 169:
[https://github.com/intermine/im-tables/issues/162](url)

The regex update ignores every line starting with #! 

Please test at: [http://kkosuge.github.io/regex-cafe/](url)
![im-tables](https://user-images.githubusercontent.com/5608284/65959627-7f757000-e420-11e9-9d5c-a9186e53dab3.png)

Thoughts? Comments?

Regards,
Asher