### PR TITLE
updated What is Galaxy link

### DIFF
--- a/src/messages/actions.js
+++ b/src/messages/actions.js
@@ -177,7 +177,7 @@ Genomespace
   GalaxyAlt: "Send to a specific Galaxy",
   SaveGalaxyURL: "Make this my default Galaxy",
   WhatIsGalaxy: "What is Galaxy?",
-  WhatIsGalaxyURL: "http://wiki.g2.bx.psu.edu/",
+  WhatIsGalaxyURL: "https://galaxyproject.org/tutorials/g101/",
   GalaxyAuthExplanation: `\
 If you have already logged into Galaxy with this browser, then the data
 will be sent into your active account. Otherwise it will appear in a 


### PR DESCRIPTION
The "What is Galaxy?" link at  https://github.com/intermine/im-tables/blob/dev/src/messages/actions.js#L180 was changed to https://galaxyproject.org/tutorials/g101/