### PR TITLE
modify npm start to run dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "repl": "coffee",
     "coffeelint": "coffeelint -f coffeelint.json",
-    "start": "grunt run:server",
+    "start": "npm run dev",
     "dev": "grunt serve",
     "test": "grunt test",
     "watch": "grunt watch",


### PR DESCRIPTION
Checkout #205 

As suggested by @uosl, the `npm run start` or `npm start` command now runs the `npm run dev` script to build and launch the project. The docs will be updated as part of #206.