### PR TITLE
modify Grunt build tasks to prevent unexpected test failure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -221,6 +221,8 @@ grunt.registerTask('style', [
   'sandbox_css'
 ]);
 
+grunt.registerTask('watchTests', ['watchTests']);
+
 grunt.registerTask('build', [
   'build:dist',
   'notify:build'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,7 @@ var serverPort = (grunt.option('port') || env.PORT || env.npm_package_config_por
 var NO_SPAWN = {spawn: false};
 
 grunt.initConfig({
-  watch: { // Hwat! This task lays out the dependency graph.
+  watchTests: { // Hwat! This task lays out the dependency graph.
     coffee: {
       files: ['src/**', 'templates/**', 'package.json'],
       tasks: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,36 @@ var serverPort = (grunt.option('port') || env.PORT || env.npm_package_config_por
 var NO_SPAWN = {spawn: false};
 
 grunt.initConfig({
+  watch: { // Hwat! This task lays out the dependency graph.
+    coffee: {
+      files: ['src/**', 'templates/**', 'package.json'],
+      tasks: [
+        'compile',
+        'build'
+      ],
+      options: NO_SPAWN
+    },
+    umd_consumers: {
+      files: ['test/scripts/**'],
+      tasks: [
+        'run:compile_umd_consumers',
+        'notify:build'
+      ],
+      options: NO_SPAWN
+    },
+    indices: {
+      files: ['test/indices/*', 'test/lib/*'],
+      tasks: [
+        'notify:build'
+      ],
+      options: NO_SPAWN
+    },
+    less: {
+      files: ['less/**'],
+      tasks: ['style'],
+      options: NO_SPAWN
+    }
+  },
   watchTests: { // Hwat! This task lays out the dependency graph.
     coffee: {
       files: ['src/**', 'templates/**', 'package.json'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,7 @@ var serverPort = (grunt.option('port') || env.PORT || env.npm_package_config_por
 var NO_SPAWN = {spawn: false};
 
 grunt.initConfig({
-  watch: { // Hwat! This task lays out the dependency graph.
+  watch: { 
     coffee: {
       files: ['src/**', 'templates/**', 'package.json'],
       tasks: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,7 @@ grunt.loadNpmTasks('grunt-contrib-uglify');
 grunt.loadNpmTasks('grunt-notify');
 grunt.loadNpmTasks('grunt-run');
 grunt.loadNpmTasks('grunt-sandbox-css');
+grunt.loadNpmTasks('grunt-concurrent');
 
 var env = process.env;
 
@@ -26,34 +27,10 @@ grunt.initConfig({
       ],
       options: NO_SPAWN
     },
-    umd_consumers: {
-      files: ['test/scripts/**'],
-      tasks: [
-        'run:compile_umd_consumers',
-        'notify:build'
-      ],
-      options: NO_SPAWN
-    },
-    indices: {
-      files: ['test/indices/*', 'test/lib/*'],
-      tasks: [
-        'notify:build'
-      ],
-      options: NO_SPAWN
-    },
-    less: {
-      files: ['less/**'],
-      tasks: ['style'],
-      options: NO_SPAWN
-    }
-  },
-  watchTests: { // Hwat! This task lays out the dependency graph.
-    coffee: {
+    coffee_test: {
       files: ['src/**', 'templates/**', 'package.json'],
       tasks: [
-        'compile',
         'run:test',
-        'build'
       ],
       options: NO_SPAWN
     },
@@ -201,6 +178,9 @@ grunt.initConfig({
         prefix: '.imtables'
       }
     }
+  },
+  concurrent: {
+    start: ['watchTests', 'serve']
   }
 });
 
@@ -221,7 +201,12 @@ grunt.registerTask('style', [
   'sandbox_css'
 ]);
 
-grunt.registerTask('watchTests', ['watchTests']);
+grunt.registerTask('watchTests', [
+  'watch:coffee_test', 
+  'watch:test',
+  'watch:test_styles',
+  'watch:indices'
+]);
 
 grunt.registerTask('build', [
   'build:dist',
@@ -245,7 +230,12 @@ grunt.registerTask('build:test', [
 grunt.registerTask('serve', [
   'build',
   'run:server',
-  'watch'
+  'watch:coffee',
+  'watch:umd_consumers',
+  'watch:less',
+  'notify:build'
 ]);
+
+grunt.registerTask('start', ['concurrent:start']);
 
 grunt.registerTask('default', ['build']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,7 +193,6 @@ grunt.registerTask('style', [
 
 grunt.registerTask('build', [
   'build:dist',
-  'build:test',
   'notify:build'
 ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -180,7 +180,11 @@ grunt.initConfig({
     }
   },
   concurrent: {
-    start: ['watchTests', 'serve']
+    start: ['watchTests', 'serve'],
+    options: {
+      logConcurrentOutput: true,
+      indent: false
+    }
   }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -2314,6 +2320,18 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2356,6 +2374,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "envify": {
       "version": "4.1.0",
@@ -3426,6 +3453,32 @@
             "abbrev": "1",
             "osenv": "^0.1.4"
           }
+        }
+      }
+    },
+    "grunt-concurrent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-3.0.0.tgz",
+      "integrity": "sha512-AgXtjUJESHEGeGX8neL3nmXBTHSj1QC48ABQ3ng2/vjuSBpDD8gKcVHSlXP71pFkIR8TQHf+eomOx6OSYSgfrA==",
+      "dev": true,
+      "requires": {
+        "arrify": "^2.0.1",
+        "async": "^3.1.0",
+        "indent-string": "^4.0.0",
+        "pad-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.1.tgz",
+          "integrity": "sha512-X5Dj8hK1pJNC2Wzo2Rcp9FBVdJMGRR/S7V+lH46s8GVFhtbo5O4Le5GECCF/8PISVdkUA6mMPvgz7qTTD1rf1g==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
         }
       }
     },
@@ -5711,6 +5764,17 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "pad-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pad-stream/-/pad-stream-2.0.0.tgz",
+      "integrity": "sha1-O+vzTNpJWXISpmny/kF9ZGp8ulY=",
+      "dev": true,
+      "requires": {
+        "pumpify": "^1.3.3",
+        "split2": "^2.1.1",
+        "through2": "^2.0.0"
+      }
+    },
     "param-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
@@ -6040,6 +6104,27 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -7063,6 +7148,15 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
+      "requires": {
+        "through2": "^2.0.2"
+      }
+    },
     "sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -7188,6 +7282,12 @@
         "to-arraybuffer": "^1.0.0",
         "xtend": "^4.0.0"
       }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
     },
     "stream-splicer": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "envify": "^4.1.0",
     "grunt": "^1.0.4",
     "grunt-cli": "^1.3.2",
+    "grunt-concurrent": "^3.0.0",
     "grunt-contrib-coffee": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-uglify": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "repl": "coffee",
     "coffeelint": "coffeelint -f coffeelint.json",
-    "start": "npm run dev",
+    "start": "grunt start",
     "dev": "grunt serve",
     "test": "grunt test",
     "watch": "grunt watch",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "npm run dev",
     "dev": "grunt serve",
     "test": "grunt test",
-    "watch": "grunt watch",
+    "watch-tests": "grunt watchTests",
     "compile": "grunt compile",
     "less": "grunt run:lessc",
     "build": "grunt build",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "npm run dev",
     "dev": "grunt serve",
     "test": "grunt test",
+    "watch": "grunt watch",
     "watch-tests": "grunt watchTests",
     "compile": "grunt compile",
     "less": "grunt run:lessc",


### PR DESCRIPTION
@uosl I've removed the `test` command from the build script in the Gruntfile. But there's another issue here. The `npm run dev` script runs `grunt serve` which in turn runs 3 tasks:
https://github.com/intermine/im-tables/blob/c2bced18e62b09c4bb468dc7eb050ec175e8e627/Gruntfile.js#L214-L218

Now build will no longer run tests but `watch` will. In fact, `watch` contains the _definition_ of the test task. So should I remove the test command from watch too and make it a separate task in `grunt.initconfig`?