### PR TITLE
Rename imtables package to im-tables in Javascript generator

### DIFF
--- a/templates/code-gen-js.js
+++ b/templates/code-gen-js.js
@@ -7,11 +7,11 @@
 <script>
 <% } %>
 <% if (!asHTML) { %>
-/* Install from npm: npm install imtables
+/* Install from npm: npm install im-tables
  * This snippet assumes the presence on the page of an element like:
  * <div id="some-elem"></div>
  */
-var imtables = require('imtables');
+var imtables = require('im-tables');
 <% } %>
 
 var selector = '#some-elem';


### PR DESCRIPTION
Solves #210 

When using Generated JavaScript Code for Query from im-tables running in InterMine, it produces a snippet that mentions the `imtables` npm package which we do not have access to.So, this replaces it to `im-tables`which is the correct package.