### PR TITLE
Popups don't show too many items

### DIFF
--- a/src/views/item-preview/details.coffee
+++ b/src/views/item-preview/details.coffee
@@ -23,13 +23,15 @@ module.exports = class ItemDetails extends CoreView
   events: ->
     'click .im-too-long': @revealLongField
 
-  postRender: -> @collection.each (details) => @addDetail details
+  postRender: ->
+    @collection.each (details) => @addDetail details
 
   addDetail: (details) ->
-    @$el.append @['render' + details.get('fieldType')] details.toJSON()
+    if details.get('type') == "String"
+      @$el.append @['render' + details.get('fieldType')] details.toJSON()
 
   renderATTR: (data) -> ATTR _.extend @getBaseData(), data
-  
+
   renderREF: REFERENCE
 
   revealLongField: (e) ->
@@ -38,4 +40,3 @@ module.exports = class ItemDetails extends CoreView
     $overSpill = @$ '.im-overspill'
     $tooLong.remove()
     $overSpill.slideDown 250
-


### PR DESCRIPTION
Solves #169 

Note:
The changes here work for all mines but I've focused primarily on yeast mine. Initially the popup for yeast mine had  40+ values. Now only 12 are shown.
I have used `details.get('type') == "String"` so that it works for all mines. Having a for loop `for(i=0; i<10; i++)`  will fail for mines having number of attributes less than 10. After looking at several mines, I've found that the number of attributes satisfying the type condition is a small number.

Screenshots:
Flymine
![popup1](https://user-images.githubusercontent.com/43354059/77083704-ed8c0e80-6a23-11ea-8a6d-f63a928b31d9.png)

Yeastmine
![popup](https://user-images.githubusercontent.com/43354059/77083728-f7157680-6a23-11ea-8c84-38f5403f9eb3.png)

