### PR TITLE
Expose the `Table.create` static method

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -67,6 +67,9 @@ exports.configure = Options.set.bind(Options)
 # :: (elem, page, query) -> Promise Table
 exports.loadTable = load Table.create
 
+# Allow 3rd parties to create a table and externally manage the view rendering
+exports.createTable = Table.create
+
 # :: (elem, page, query) -> Promise Dashboard
 exports.loadDash = load (opts) -> new Dashboard opts
 


### PR DESCRIPTION
As part of the rewrite for the data browser, I'd like to handle rendering the view myself,
rather than with this library. This library will still be responsible for creating the table data
structure.

This commit exposes just the `Table.create` static method to allow us.