### PR TITLE
changes input.size() to input.length in pagination.coffee

### DIFF
--- a/src/views/table/pagination.coffee
+++ b/src/views/table/pagination.coffee
@@ -81,7 +81,7 @@ module.exports = class Pagination extends View
     e?.preventDefault()
     pageForm = @$('.im-page-form')
     input = @$('.im-page-form input')
-    if input.size()
+    if input.length
       destination = ensureNumber input[0].value
       if destination >= 1
         page = Math.min @getMaxPage(), destination


### PR DESCRIPTION

**ISSUE: Arbitrary page option doesn't work #227**

I changed input.size() to input.length in src/views/table/pagination.coffee. This fixes the issue with the 'arbitrary page option button'. 

This is my first PR in im-tables, so please do let me know if there are any mistakes in my submission, and I will be happy to correct them :) 

**Before change**

![err_1](https://user-images.githubusercontent.com/52915849/100443462-a883a600-30a1-11eb-810b-c2c602124c79.PNG)

**After change**

![err_1_fixed](https://user-images.githubusercontent.com/52915849/100443482-b0dbe100-30a1-11eb-8f47-afcb94649278.PNG)
